### PR TITLE
Start node property

### DIFF
--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -88,7 +88,7 @@ class SuiteProcessors:
         out_suite.suites = []
         return out_suite
 
-    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = 'reduced-sdv') -> Suite:
+    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = '') -> Suite:
         self.out_suite = Suite(in_suite.name)
         self.out_suite.filename = in_suite.filename
         self.out_suite.parent = in_suite.parent

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -88,7 +88,7 @@ class SuiteProcessors:
         out_suite.suites = []
         return out_suite
 
-    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = 'scenario-delta-value') -> Suite:
+    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = 'reduced-sdv') -> Suite:
         self.out_suite = Suite(in_suite.name)
         self.out_suite.filename = in_suite.filename
         self.out_suite.parent = in_suite.parent

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -88,7 +88,7 @@ class SuiteProcessors:
         out_suite.suites = []
         return out_suite
 
-    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = '') -> Suite:
+    def process_test_suite(self, in_suite: Suite, *, seed: any = 'new', graph: str = 'scenario-delta-value') -> Suite:
         self.out_suite = Suite(in_suite.name)
         self.out_suite.filename = in_suite.filename
         self.out_suite.parent = in_suite.parent

--- a/robotmbt/visualise/graphs/abstractgraph.py
+++ b/robotmbt/visualise/graphs/abstractgraph.py
@@ -19,6 +19,7 @@ class AbstractGraph(ABC, Generic[NodeInfo, EdgeInfo]):
 
         # Add the start node
         self.networkx.add_node('start', label='start')
+        self.start_node = 'start'
 
         # Add nodes and edges for all traces
         for trace in info.all_traces:

--- a/robotmbt/visualise/graphs/reducedSDVgraph.py
+++ b/robotmbt/visualise/graphs/reducedSDVgraph.py
@@ -1,9 +1,10 @@
 import networkx
-from robotmbt.modelspace import ModelSpace
 
+from robotmbt.modelspace import ModelSpace
 from robotmbt.visualise.graphs.abstractgraph import AbstractGraph
 from robotmbt.visualise.graphs.scenariodeltavaluegraph import ScenarioDeltaValueGraph
 from robotmbt.visualise.models import ScenarioInfo, StateInfo, TraceInfo
+
 
 # TODO add tests for this graph representation
 class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], None]):
@@ -18,8 +19,9 @@ class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], N
     def chain_equiv(self, node1, node2) -> bool:
         context = self.networkx
         if not node1 == 'start' and not node2 == 'start' and self.ids[node1][0] == self.ids[node2][0] and \
-                (context.has_edge(node1, node2) or context.has_edge(node2, node1)):
-            return len(set(context.edges(node1)) ^ set(context.edges(node2))) <= 2
+                (networkx.has_path(context, node1, node2) or networkx.has_path(context, node2, node1)):
+            return len(set(context.in_edges(node1)) ^ set(context.in_edges(node2))) <= 2 and \
+                len(set(context.out_edges(node1)) ^ set(context.out_edges(node2))) <= 2
         else:
             return False
 

--- a/robotmbt/visualise/graphs/reducedSDVgraph.py
+++ b/robotmbt/visualise/graphs/reducedSDVgraph.py
@@ -39,6 +39,7 @@ class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], N
             for new_node in nodes:
                 if current_node in new_node:
                     self.final_trace[i] = new_node
+        self.start_node = frozenset(['start'])
 
     @staticmethod
     def select_node_info(pairs: list[tuple[ScenarioInfo, StateInfo]], index: int) \

--- a/robotmbt/visualise/networkvisualiser.py
+++ b/robotmbt/visualise/networkvisualiser.py
@@ -147,7 +147,7 @@ class NetworkVisualiser:
             node_color = self.EXECUTED_NODE_COLOR if is_executed else self.UNEXECUTED_NODE_COLOR
             text_color = self.EXECUTED_TEXT_COLOR if is_executed else self.UNEXECUTED_TEXT_COLOR
 
-            if node == 'start':
+            if node == self.graph.start_node:
                 # For start node (circle), calculate radius based on text width
                 text_width, text_height = self._calculate_text_dimensions(
                     label)
@@ -440,7 +440,7 @@ class NetworkVisualiser:
     def _calculate_graph_layout(self):
         try:
             self.graph_layout = nx.bfs_layout(
-                self.graph.networkx, 'start', align='horizontal')
+                self.graph.networkx, self.graph.start_node, align='horizontal')
             # horizontal mirror
             for node in self.graph_layout:
                 self.graph_layout[node] = (self.graph_layout[node][0],


### PR DESCRIPTION
fixed bfs layout for reduced SDV graphs by adding start_node property to AbstractGraph. start_node can be used for future graphs with a different start_node id as well