### PR TITLE
Convert reduced-sdv ids into tuples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,8 @@ To create a new graph type, create an instance of AbstractGraph, instantiating t
 
 It is recommended to create a new file for each graph type under `/robotmbt/visualise/graphs/`.
 
+NOTE: when manually altering the networkx field, ensure its ids remain as a hashable type when the constructor finishes.
+
 A simple example is given below. In this graph type, nodes represent scenarios encountered in exploration, and edges show the flow between these scenarios.
 
 ```python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ To create a new graph type, create an instance of AbstractGraph, instantiating t
 
 It is recommended to create a new file for each graph type under `/robotmbt/visualise/graphs/`.
 
-NOTE: when manually altering the networkx field, ensure its ids remain as a hashable type when the constructor finishes.
+NOTE: when manually altering the networkx field, ensure its ids remain as a serializable type when the constructor finishes.
 
 A simple example is given below. In this graph type, nodes represent scenarios encountered in exploration, and edges show the flow between these scenarios.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ To create a new graph type, create an instance of AbstractGraph, instantiating t
 
 It is recommended to create a new file for each graph type under `/robotmbt/visualise/graphs/`.
 
-NOTE: when manually altering the networkx field, ensure its ids remain as a serializable type when the constructor finishes.
+NOTE: when manually altering the networkx field, ensure its ids remain as a serializable and hashable type when the constructor finishes.
 
 A simple example is given below. In this graph type, nodes represent scenarios encountered in exploration, and edges show the flow between these scenarios.
 

--- a/atest/resources/helpers/modelgenerator.py
+++ b/atest/resources/helpers/modelgenerator.py
@@ -5,7 +5,7 @@ from robotmbt.visualise.visualiser import Visualiser
 from robotmbt.visualise.graphs.abstractgraph import AbstractGraph
 import os
 import networkx as nx
-from robotmbt.visualise.networkvisualiser import NetworkVisualiser, RawNodeInfo
+from robotmbt.visualise.networkvisualiser import NetworkVisualiser, Node
 
 
 class ModelGenerator:
@@ -120,8 +120,8 @@ class ModelGenerator:
             return None
 
         try:
-            raw_node_info: RawNodeInfo | None = network_vis.raw_node_info[id]
-            return raw_node_info.y
+            node: Node | None = network_vis.node_dict[id]
+            return node.y
         except KeyError:
             return None
 

--- a/robotmbt/visualise/graphs/abstractgraph.py
+++ b/robotmbt/visualise/graphs/abstractgraph.py
@@ -12,7 +12,7 @@ EdgeInfo = TypeVar('EdgeInfo')
 class AbstractGraph(ABC, Generic[NodeInfo, EdgeInfo]):
     def __init__(self, info: TraceInfo):
         """
-        Note that networkx's ids have to be of a serializable type after construction.
+        Note that networkx's ids have to be of a serializable and hashable type after construction.
         """
         # The underlying storage - a NetworkX DiGraph
         self.networkx: nx.DiGraph = nx.DiGraph()

--- a/robotmbt/visualise/graphs/abstractgraph.py
+++ b/robotmbt/visualise/graphs/abstractgraph.py
@@ -12,7 +12,7 @@ EdgeInfo = TypeVar('EdgeInfo')
 class AbstractGraph(ABC, Generic[NodeInfo, EdgeInfo]):
     def __init__(self, info: TraceInfo):
         """
-        Note that networkx's ids have to be of a hashable type after construction.
+        Note that networkx's ids have to be of a serializable type after construction.
         """
         # The underlying storage - a NetworkX DiGraph
         self.networkx: nx.DiGraph = nx.DiGraph()

--- a/robotmbt/visualise/graphs/abstractgraph.py
+++ b/robotmbt/visualise/graphs/abstractgraph.py
@@ -11,6 +11,9 @@ EdgeInfo = TypeVar('EdgeInfo')
 
 class AbstractGraph(ABC, Generic[NodeInfo, EdgeInfo]):
     def __init__(self, info: TraceInfo):
+        """
+        Note that networkx's ids have to be of a hashable type after construction.
+        """
         # The underlying storage - a NetworkX DiGraph
         self.networkx: nx.DiGraph = nx.DiGraph()
 

--- a/robotmbt/visualise/graphs/reducedSDVgraph.py
+++ b/robotmbt/visualise/graphs/reducedSDVgraph.py
@@ -41,12 +41,32 @@ class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], N
                                                 edge_data=lambda x, y: {'label': ''})
         # TODO make generated label more obvious to be equivalence class
         nodes = self.networkx.nodes
+
+        new_networkx = networkx.DiGraph()
+
+        for node_id in self.networkx.nodes:
+            new_id = self._frozenset_id_to_str(node_id)
+            new_networkx.add_node(new_id)
+            new_networkx.nodes[new_id]['label'] = self.networkx.nodes[node_id]['label']
+
+        for (from_id, to_id) in self.networkx.edges:
+            new_from_id = self._frozenset_id_to_str(from_id)
+            new_to_id = self._frozenset_id_to_str(to_id)
+            new_networkx.add_edge(new_from_id, new_to_id)
+            new_networkx.edges[(new_from_id, new_to_id)]['label'] = self.networkx.edges[(from_id, to_id)]['label']
+
         for i in range(len(self.final_trace)):
             current_node = self.final_trace[i]
             for new_node in nodes:
                 if current_node in new_node:
-                    self.final_trace[i] = new_node
-        self.start_node = frozenset(['start'])
+                    self.final_trace[i] = self._frozenset_id_to_str(new_node)
+
+        self.networkx = new_networkx
+        self.start_node = self._frozenset_id_to_str(frozenset(['start']))
+
+    @staticmethod
+    def _frozenset_id_to_str(frozen: frozenset[str]) -> str:
+        return str(sorted(frozen))
 
     @staticmethod
     def select_node_info(pairs: list[tuple[ScenarioInfo, StateInfo]], index: int) \

--- a/robotmbt/visualise/graphs/reducedSDVgraph.py
+++ b/robotmbt/visualise/graphs/reducedSDVgraph.py
@@ -42,16 +42,16 @@ class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], N
         # TODO make generated label more obvious to be equivalence class
         nodes = self.networkx.nodes
 
-        new_networkx = networkx.DiGraph()
+        new_networkx: networkx.DiGraph = networkx.DiGraph()
 
         for node_id in self.networkx.nodes:
-            new_id = self._frozenset_id_to_str(node_id)
+            new_id: tuple[str, ...] = tuple(sorted(node_id))
             new_networkx.add_node(new_id)
             new_networkx.nodes[new_id]['label'] = self.networkx.nodes[node_id]['label']
 
         for (from_id, to_id) in self.networkx.edges:
-            new_from_id = self._frozenset_id_to_str(from_id)
-            new_to_id = self._frozenset_id_to_str(to_id)
+            new_from_id: tuple[str, ...] = tuple(sorted(from_id))
+            new_to_id: tuple[str, ...] = tuple(sorted(to_id))
             new_networkx.add_edge(new_from_id, new_to_id)
             new_networkx.edges[(new_from_id, new_to_id)]['label'] = self.networkx.edges[(from_id, to_id)]['label']
 
@@ -59,14 +59,10 @@ class ReducedSDVGraph(AbstractGraph[tuple[ScenarioInfo, set[tuple[str, str]]], N
             current_node = self.final_trace[i]
             for new_node in nodes:
                 if current_node in new_node:
-                    self.final_trace[i] = self._frozenset_id_to_str(new_node)
+                    self.final_trace[i] = tuple(sorted(new_node))
 
         self.networkx = new_networkx
-        self.start_node = self._frozenset_id_to_str(frozenset(['start']))
-
-    @staticmethod
-    def _frozenset_id_to_str(frozen: frozenset[str]) -> str:
-        return str(sorted(frozen))
+        self.start_node: tuple[str, ...] = tuple(['start'])
 
     @staticmethod
     def select_node_info(pairs: list[tuple[ScenarioInfo, StateInfo]], index: int) \

--- a/robotmbt/visualise/networkvisualiser.py
+++ b/robotmbt/visualise/networkvisualiser.py
@@ -460,16 +460,6 @@ def _add_edge_to_sources(nodes: list[Node], edge: Edge, final_trace: list[str], 
     start_x, start_y = 0, 0
     end_x, end_y = 0, 0
 
-    if isinstance(edge.from_node, frozenset):
-        from_id = tuple(sorted(edge.from_node))
-    else:
-        from_id = edge.from_node
-
-    if isinstance(edge.to_node, frozenset):
-        to_id = tuple(sorted(edge.to_node))
-    else:
-        to_id = edge.to_node
-
     # Add edges going through the calculated points
     for i in range(len(edge.points) - 1):
         start_x, start_y = edge.points[i]
@@ -491,8 +481,8 @@ def _add_edge_to_sources(nodes: list[Node], edge: Edge, final_trace: list[str], 
 
         if i < len(edge.points) - 2:
             # Middle part of edge without arrow
-            edge_part_source.data['from'].append(from_id)
-            edge_part_source.data['to'].append(to_id)
+            edge_part_source.data['from'].append(edge.from_node)
+            edge_part_source.data['to'].append(edge.to_node)
             edge_part_source.data['start_x'].append(start_x)
             edge_part_source.data['start_y'].append(-start_y)
             edge_part_source.data['end_x'].append(end_x)
@@ -500,8 +490,8 @@ def _add_edge_to_sources(nodes: list[Node], edge: Edge, final_trace: list[str], 
             edge_part_source.data['color'].append(FINAL_TRACE_EDGE_COLOR if in_final_trace else OTHER_EDGE_COLOR)
         else:
             # End of edge with arrow
-            edge_arrow_source.data['from'].append(from_id)
-            edge_arrow_source.data['to'].append(to_id)
+            edge_arrow_source.data['from'].append(edge.from_node)
+            edge_arrow_source.data['to'].append(edge.to_node)
             edge_arrow_source.data['start_x'].append(start_x)
             edge_arrow_source.data['start_y'].append(-start_y)
             edge_arrow_source.data['end_x'].append(end_x)
@@ -509,8 +499,8 @@ def _add_edge_to_sources(nodes: list[Node], edge: Edge, final_trace: list[str], 
             edge_arrow_source.data['color'].append(FINAL_TRACE_EDGE_COLOR if in_final_trace else OTHER_EDGE_COLOR)
 
     # Add the label
-    edge_label_source.data['from'].append(from_id)
-    edge_label_source.data['to'].append(to_id)
+    edge_label_source.data['from'].append(edge.from_node)
+    edge_label_source.data['to'].append(edge.to_node)
     edge_label_source.data['x'].append((start_x + end_x) / 2)
     edge_label_source.data['y'].append(- (start_y + end_y) / 2)
     edge_label_source.data['label'].append(edge.label)
@@ -523,21 +513,11 @@ def _add_self_loop_to_sources(nodes: list[Node], edge: Edge, in_final_trace: boo
     """
     connection = _get_connection_coordinates(nodes, edge.from_node)
 
-    if isinstance(edge.from_node, frozenset):
-        from_id = tuple(sorted(edge.from_node))
-    else:
-        from_id = edge.from_node
-
-    if isinstance(edge.to_node, frozenset):
-        to_id = tuple(sorted(edge.to_node))
-    else:
-        to_id = edge.to_node
-
     right_x, right_y = connection[1]
 
     # Add the Bézier curve
-    edge_bezier_source.data['from'].append(from_id)
-    edge_bezier_source.data['to'].append(to_id)
+    edge_bezier_source.data['from'].append(edge.from_node)
+    edge_bezier_source.data['to'].append(edge.to_node)
     edge_bezier_source.data['start_x'].append(right_x)
     edge_bezier_source.data['start_y'].append(-right_y + 5)
     edge_bezier_source.data['end_x'].append(right_x)
@@ -549,8 +529,8 @@ def _add_self_loop_to_sources(nodes: list[Node], edge: Edge, in_final_trace: boo
     edge_bezier_source.data['color'].append(FINAL_TRACE_EDGE_COLOR if in_final_trace else OTHER_EDGE_COLOR)
 
     # Add the arrow
-    edge_arrow_source.data['from'].append(from_id)
-    edge_arrow_source.data['to'].append(to_id)
+    edge_arrow_source.data['from'].append(edge.from_node)
+    edge_arrow_source.data['to'].append(edge.to_node)
     edge_arrow_source.data['start_x'].append(right_x + 0.001)
     edge_arrow_source.data['start_y'].append(-right_y - 5.001)
     edge_arrow_source.data['end_x'].append(right_x)
@@ -558,8 +538,8 @@ def _add_self_loop_to_sources(nodes: list[Node], edge: Edge, in_final_trace: boo
     edge_arrow_source.data['color'].append(FINAL_TRACE_EDGE_COLOR if in_final_trace else OTHER_EDGE_COLOR)
 
     # Add the label
-    edge_label_source.data['from'].append(from_id)
-    edge_label_source.data['to'].append(to_id)
+    edge_label_source.data['from'].append(edge.from_node)
+    edge_label_source.data['to'].append(edge.to_node)
     edge_label_source.data['x'].append(right_x + 25)
     edge_label_source.data['y'].append(-right_y)
     edge_label_source.data['label'].append(edge.label)
@@ -570,13 +550,7 @@ def _add_node_to_sources(node: Node, final_trace: list[str], node_source: Column
     """
     Add a node to the ColumnDataSources.
     """
-    node_id: str | tuple[str, ...]
-    if isinstance(node.node_id, frozenset):
-        node_id = tuple(sorted(node.node_id))
-    else:
-        node_id = node.node_id
-
-    node_source.data['id'].append(node_id)
+    node_source.data['id'].append(node.node_id)
     node_source.data['x'].append(node.x)
     node_source.data['y'].append(-node.y)
     node_source.data['w'].append(node.width)
@@ -584,13 +558,13 @@ def _add_node_to_sources(node: Node, final_trace: list[str], node_source: Column
     node_source.data['color'].append(
         FINAL_TRACE_NODE_COLOR if node.node_id in final_trace else OTHER_NODE_COLOR)
 
-    node_label_source.data['id'].append(node_id)
+    node_label_source.data['id'].append(node.node_id)
     node_label_source.data['x'].append(node.x - node.width / 2 + HORIZONTAL_PADDING_WITHIN_NODES)
     node_label_source.data['y'].append(-node.y)
     node_label_source.data['label'].append(node.label)
 
     return RawNodeInfo(
-        id=node_id,
+        id=node.node_id,
         label=node.label,
         x=node.x,
         y=node.y,


### PR DESCRIPTION
Makes the reduced-sdv graphs in line with other graph types to just have string ids for nodes.